### PR TITLE
Adds the GUI for user to manually select constraint.sdc and config.mk

### DIFF
--- a/mode_dark_light.py
+++ b/mode_dark_light.py
@@ -31,7 +31,8 @@ if args.theme:
        CANVAS_BG_COLOR = "#E5E5E5"
        CANVAS_LINE_COLOR = "black"
 
-from VectorCGRA.cgra.translate.CGRATemplateRTL_test import *
+#from VectorCGRA.cgra.translate.CGRATemplateRTL_test import *
+from VectorCGRA.cgra.translate.CGRARTL_test import *
 
 # importing module
 import logging
@@ -964,7 +965,8 @@ def clickGenerateVerilog():
     os.chdir("verilog")
 
     # pymtl function that is used to generate synthesizable verilog
-    test_cgra_universal(paramCGRA)
+    #test_cgra_universal(paramCGRA)
+    test_cgra_universal()
 
     widgets["verilogText"].delete("1.0", tkinter.END)
     found = False
@@ -982,7 +984,8 @@ def clickGenerateVerilog():
         paramCGRA.verilogDone = False
         widgets["verilogText"].insert(tkinter.END, "Error exists during Verilog generation")
 
-    os.system("mv CGRATemplateRTL__*.v design.v")
+    #os.system("mv CGRATemplateRTL__*.v design.v")
+    os.system("mv CGRARTL__*.v design.v")
     # os.system("rename s/\.v/\.log/g *")
 
     os.chdir("..")
@@ -2227,7 +2230,7 @@ def runOpenRoad(mk_sdc_file_path, cmd_path, odb_path, layout_path):
 
 def clickRTL2Layout():
     global constraintFilePath, configFilePath
-    standard_module_name = "CGRATemplateRTL"
+    standard_module_name = "CGRARTL"
     cgraflow_basepath = os.path.dirname(os.path.abspath(__file__))
     test_platform_name = processOptions.get()
     print("Test platform is %s" % (test_platform_name))

--- a/mode_dark_light.py
+++ b/mode_dark_light.py
@@ -31,8 +31,7 @@ if args.theme:
        CANVAS_BG_COLOR = "#E5E5E5"
        CANVAS_LINE_COLOR = "black"
 
-#from VectorCGRA.cgra.translate.CGRATemplateRTL_test import *
-from VectorCGRA.cgra.translate.CGRARTL_test import *
+from VectorCGRA.cgra.translate.CGRATemplateRTL_test import *
 
 # importing module
 import logging
@@ -965,8 +964,7 @@ def clickGenerateVerilog():
     os.chdir("verilog")
 
     # pymtl function that is used to generate synthesizable verilog
-    #test_cgra_universal(paramCGRA)
-    test_cgra_universal()
+    test_cgra_universal(paramCGRA)
 
     widgets["verilogText"].delete("1.0", tkinter.END)
     found = False
@@ -984,8 +982,7 @@ def clickGenerateVerilog():
         paramCGRA.verilogDone = False
         widgets["verilogText"].insert(tkinter.END, "Error exists during Verilog generation")
 
-    #os.system("mv CGRATemplateRTL__*.v design.v")
-    os.system("mv CGRARTL__*.v design.v")
+    os.system("mv CGRATemplateRTL__*.v design.v")
     # os.system("rename s/\.v/\.log/g *")
 
     os.chdir("..")
@@ -2230,7 +2227,7 @@ def runOpenRoad(mk_sdc_file_path, cmd_path, odb_path, layout_path):
 
 def clickRTL2Layout():
     global constraintFilePath, configFilePath
-    standard_module_name = "CGRARTL"
+    standard_module_name = "CGRATemplateRTL"
     cgraflow_basepath = os.path.dirname(os.path.abspath(__file__))
     test_platform_name = processOptions.get()
     print("Test platform is %s" % (test_platform_name))


### PR DESCRIPTION
Hi cheng,

I have added two file dialogs in the layout pannel for user to choose constraint.sdc and config.mk.
User must choose this file before clicking button `RTL->Layout`, otherwise a `file missing error` dialog will pop up:
<img width="271" alt="1" src="https://github.com/user-attachments/assets/58e1a852-585a-4f63-9ae6-89c789f996c2"> <img width="248" alt="2" src="https://github.com/user-attachments/assets/5f2bbe25-fddc-4726-b9f9-699cfbdbcd25">

I once think about letting users to edit those two files within CGRA-Flow GUI, but this function is not directly supported by customtkinter, so I only achieve this in a straighforward way so that I can focus more on addressing the verilog transformation issue.

So, apart from this issue, is there any other GUI stuff that you think can be better optimized for conference demo if we have time left? Here are some of my intuitions:

- We can seperate the internal stages of `RTL->Layout` including `synthesis`, `floorplan`, `place`, `cts`, `grt`, and `route `to individual pannels, so that we can extract metrics from the OpenRoad stage report and show them on the respective pannels.
- We can also print the logs of each stage to their respective pannels using a text box so that user knows current stage is running.

Best regards,
Yufei
