### PR TITLE
Add default cmdline opts as test_cgra_universal method changed

### DIFF
--- a/launchUI.bash
+++ b/launchUI.bash
@@ -4,11 +4,11 @@ input_theme=$1
 echo "Theme: $input_theme"
 
 cd build
-if [ "$input_theme" == "classic" ]; then
+if [ "$input_theme" = "classic" ]; then
       echo "classic theme selected"
       #start dark theme
       python ../mode_classic.py
-elif [ "$input_theme" == "light" ]; then
+elif [ "$input_theme" = "light" ]; then
       echo "light theme selected"
       #start light theme
       python ../mode_dark_light.py --theme light

--- a/mode_dark_light.py
+++ b/mode_dark_light.py
@@ -964,6 +964,8 @@ def clickGenerateVerilog():
     os.chdir("verilog")
 
     # pymtl function that is used to generate synthesizable verilog
+    cmdline_opts = {'test_verilog': 'zeros', 'test_yosys_verilog': '', 'dump_textwave': False, 'dump_vcd': False,
+                    'dump_vtb': False, 'max_cycles': None}
     test_cgra_universal(paramCGRA = paramCGRA)
 
     widgets["verilogText"].delete("1.0", tkinter.END)


### PR DESCRIPTION
Refer to: [Commit a7a478a](https://github.com/yuqisun/VectorCGRA/commit/a7a478ac06b288c1a6fd88915d000cc0b316c4e7#diff-7c75d763e7c9a3f4d1de3ea7cd2d09dfc29badd8d61e30cd62648f7816d12d26R173) in CGRATemplateRTL_test.py

to fix issue below when 'Generate Sverilog' from GUI:

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "/home/syq/anaconda3/envs/py39/lib/python3.9/tkinter/__init__.py", line 1892, in __call__
	return self.func(*args)
  File "/home/syq/anaconda3/envs/py39/lib/python3.9/site-packages/customtkinter/windows/widgets/ctk_button.py", line 554, in _clicked
	self._command()
  File "/home/syq/cgra/CGRA-Flow/build/../mode_dark_light.py", line 967, in clickGenerateVerilog
	test_cgra_universal(paramCGRA = paramCGRA)
TypeError: test_cgra_universal() missing 1 required positional argument: 'cmdline_opts'
```


