### PR TITLE
use absolute file path for images for facilitating debug purpose

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -8,7 +8,8 @@ customtkinter.set_appearance_mode("Dark")
 customtkinter.set_default_color_theme("dark-blue")
 
 master = customtkinter.CTk()
-image_path = './theme/'
+script_dir = os.path.dirname(os.path.abspath(__file__))
+image_path = os.path.join(script_dir, "theme")
 theme_selector_dark_image = customtkinter.CTkImage(Image.open(os.path.join(image_path, "dark_theme.png")), size=(500, 410))
 theme_selector_light_image = customtkinter.CTkImage(Image.open(os.path.join(image_path, "light_theme.png")), size=(500, 410))
 theme_selector_classic_image = customtkinter.CTkImage(Image.open(os.path.join(image_path, "classic_theme.png")), size=(500, 410))


### PR DESCRIPTION
When performing remote debugging, remote IDE may default change dir to parent or root folder and perform debugging steps 


```
cd /WORK_REPO ; /usr/bin/env /WORK_REPO/venv/bin/python /root/.vscode-server/extensions/ms-python.debugpy-2025.0.1-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher 47463 -- /WORK_REPO/CGRA-Flow/launch.py 
```

Replace current relative file path to absolute anyway to facilitate debugging and bring no hard to current local container setup steps.