### PR TITLE
Reversed Heuristic and Exhaustive buttons #54: fix issue and correct typo

### DIFF
--- a/mode_dark_light.py
+++ b/mode_dark_light.py
@@ -1501,7 +1501,7 @@ def clickTerminateMapping():
 def clickMapDFG():
     global mappingProc
     mappingProc = None
-    heuristic = mappingAlgoCheckVar.get() == 1
+    heuristic = mappingAlgoCheckVar.get() == 0
 
     os.system("mkdir kernel")
     os.chdir("kernel")
@@ -2383,12 +2383,12 @@ def create_kernel_pannel(master):
                                             font=customtkinter.CTkFont(size=FRAME_LABEL_FONT_SIZE,
                                                                        weight="bold"))
     mappingOptionLabel.grid(row=0, column=0, columnspan=2)
-    heuristicRatiobutton = customtkinter.CTkRadioButton(mappingAlgoPannel, text="Heuristic", variable=mappingAlgoCheckVar, value=0)
-    widgets["heuristicRatiobutton"] = heuristicRatiobutton
-    heuristicRatiobutton.grid(row=1, column=0, pady=(0, 5), sticky="nsew")
-    exhaustiveRatiobutton = customtkinter.CTkRadioButton(mappingAlgoPannel, text="Exhaustive", variable=mappingAlgoCheckVar, value=1)
-    widgets["exhaustiveRatiobutton"] = exhaustiveRatiobutton
-    exhaustiveRatiobutton.grid(row=1, column=1, pady=(0, 5), sticky="nsew")
+    heuristicRadioButton = customtkinter.CTkRadioButton(mappingAlgoPannel, text="Heuristic", variable=mappingAlgoCheckVar, value=0)
+    widgets["heuristicRadioButton"] = heuristicRadioButton
+    heuristicRadioButton.grid(row=1, column=0, pady=(0, 5), sticky="nsew")
+    exhaustiveRadioButton = customtkinter.CTkRadioButton(mappingAlgoPannel, text="Exhaustive", variable=mappingAlgoCheckVar, value=1)
+    widgets["exhaustiveRadioButton"] = exhaustiveRadioButton
+    exhaustiveRadioButton.grid(row=1, column=1, pady=(0, 5), sticky="nsew")
 
     mapDFGButton = customtkinter.CTkButton(kernelPannel, text="Map DFG", command=clickMapDFG,)
     mapDFGButton.grid(row=8, column=2, columnspan=2, sticky="new")


### PR DESCRIPTION
Reproduced issue and fixed in code, will update image later:

```
(venv) root@ea0020241f0b kernel# more param.json
{
    "kernel": "_Z6kernelPfS_S_",
    "targetFunction": false,
    "targetNested": true,
    "targetLoopsID": [
        0
    ],
    "doCGRAMapping": true,
    "row": 2,
    "column": 2,
    "precisionAware": false,
    "heterogeneity": false,
    "isTrimmedDemo": true,
    "heuristicMapping": true,
    "parameterizableCGRA": true,
    "diagonalVectorization": false,
    "bypassConstraint": 8,
    "isStaticElasticCGRA": false,
    "ctrlMemConstraint": 8,
    "regConstraint": 12
}
```