### PR TITLE
Disable MIT-SHM for Mac OS for UI render

### DIFF
--- a/run_mac_docker.sh
+++ b/run_mac_docker.sh
@@ -21,4 +21,7 @@ docker run \
     -v $XAUTH:$XAUTH:rw \
     -e DISPLAY=$IPADDR:$DISP_NUM \
     -e XAUTHORITY=$XAUTH \
+    -e QT_X11_NO_MITSHM=1 \
+    -e _X11_NO_MITSHM=1 \
+    -e NO_AT_BRIDGE=1 \
     $CONTAINER


### PR DESCRIPTION
Suspect this isn't related to the specific project — other Docker UIs might also fail to render on your Mac. 
Please try this PR, which disables the MIT Shared Memory Extension for sockets in the startup script.

--- Recommend from Claude Opus 4.5 :)