### PR TITLE
[Fix] Delete the verilog files before generating verilog.

### DIFF
--- a/mode_dark_light.py
+++ b/mode_dark_light.py
@@ -606,6 +606,7 @@ def clickGenerateVerilog():
         return
 
     dumpArchYaml('arch.yaml')
+    os.system("rm -r verilog")
     os.system("mkdir verilog")
     os.chdir("verilog")
 


### PR DESCRIPTION
As we discussed in email, if there are other verilog files including the `__` in their filename in `build/verilog` folder, GUI may accidentally select and display other file instead of `MeshMultiCgraTemplateRTL__xxx__pickled.v`.

So we delete all the verilog files in `build/verilog` before generating `MeshMultiCgraTemplateRTL__xxx__pickled.v` to make sure there is only a verilog file(multi-cgra) for GUI to select and display.